### PR TITLE
PR to prove jacoco 0.8.7 bug (update parent to 13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.github.m-m-m</groupId>
     <artifactId>mmm</artifactId>
-    <version>12</version>
+    <version>13</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>mmm-base-parent</artifactId>


### PR DESCRIPTION
This PR only updates parent pom from 12 to 13.
The only change between these two versions is the change of jacoco.version from 0.8.5 to 0.8.7.
However, it will break the compiler plugin that should be properly configured to java11.